### PR TITLE
Refactor for hapi 8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ exports.register = function(plugin, options, next) {
   var settings = Hoek.applyToDefaults(internals.defaults, options);
   var redisClient = redis.createClient(options.redis.port, options.redis.host, options.redis.options);
 
-  plugin.ext('onPreAuth', function(request, callback) {
+  plugin.ext('onPreAuth', function(request, reply) {
     var route = request.route;
     var routeLimit = route.plugins && route.plugins['hapi-ratelimit'];
     if (!routeLimit && settings.global.limit > 0) {
@@ -40,7 +40,7 @@ exports.register = function(plugin, options, next) {
       var error = null;
       routeLimiter.get(function(err, rateLimit) {
         if (err) {
-          return callback(err);
+          return reply(err);
         }
         request.plugins['hapi-ratelimit'] = {};
         request.plugins['hapi-ratelimit'].limit = rateLimit.total;
@@ -55,14 +55,14 @@ exports.register = function(plugin, options, next) {
           error.output.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
           error.reformat();
         }
-        return callback(error);
+        return reply(error);
       });
     } else {
-      return callback();
+      return reply();
     }
   });
 
-  plugin.ext('onPostHandler', function(request, callback) {
+  plugin.ext('onPostHandler', function(request, reply) {
     var response;
     if ('hapi-ratelimit' in request.plugins) {
       response = request.response;
@@ -72,7 +72,7 @@ exports.register = function(plugin, options, next) {
         response.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
       }
     }
-    callback();
+    reply();
   });
   next();
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,11 +54,13 @@ exports.register = function(plugin, options, next) {
           error.output.headers['X-Rate-Limit-Remaining'] = request.plugins['hapi-ratelimit'].remaining;
           error.output.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
           error.reformat();
+          return reply(error);
+        } else {
+          return reply.continue();
         }
-        return reply(error);
       });
     } else {
-      return reply();
+      return reply.continue();
     }
   });
 
@@ -72,7 +74,7 @@ exports.register = function(plugin, options, next) {
         response.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
       }
     }
-    reply();
+    reply.continue();
   });
   next();
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hoek": "~2.3.0"
   },
   "devDependencies": {
-    "hapi": "~6.0.0",
+    "hapi": ">=8.0.0",
     "supertest": "~0.8.3",
     "simple-ansi": "0.0.1",
     "moment": "~2.5.1",


### PR DESCRIPTION
Without this changes, I wasn't able to run hapi-ratelimit on the latest version of hapi.

Trade-off: Due to this changes, I think this might not be compatible with versions of hapi under 8.0.0.

My changes were based on the hapi documentation: http://hapijs.com/api
