### PR TITLE
Hapi 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# hapi-ratelimit [![](https://travis-ci.org/creativelive/hapi-ratelimit.png)](https://travis-ci.org/creativelive/hapi-ratelimit)
+# hapi-ratelimit
 
 A simple ip based rate limiting plugin for Hapi using Redis.
 
+This is a fork from the [creativelive](https://github.com/creativelive/hapi-ratelimit) project. It adds support to **Hapi 8**.
 
 ##Installation
-  npm install hapi-ratelimit
+
+```
+npm install hapi-ratelimit/franciscogouveia
+```
 
 ## Usage
 
@@ -12,29 +16,48 @@ In the Hapi init code:
 ```javascript
 var Hapi = require('hapi');
 var hratelimit = require('hapi-ratelimit');
-var server = Hapi.createServer();
+var server = new Hapi.Server();
+
+// Config for ratelimit
 var rateOpts = {
-  redis:{port:#redis-port#, host:#redis-host#},
-  namespace:"clhr", //namespace for redis keys
-  global: {limit: 200, duration: 60 } //Set limit to -1 or leave out global to disable global limit
+  redis:{
+    port:#redis-port#,
+    host:#redis-host#
+  },
+  namespace: "clhr", //namespace for redis keys
+  global: {
+    limit: 200, 
+    duration: 60 
+  } //Set limit to -1 or leave out global to disable global limit
   //The global limit is not given priority over local limits
 };
-server.route({
+
+var connection = server.connection({
+  port: 80,
+  labels: 'something'
+});
+
+connection.route({
   method: 'GET',
   path: '/someImportantRoute',
   handler: someHandler,
   configs: {
-    plugins: {
-       "hapi-ratelimit": {limit: 100, duration: 60} //limits to one hundred hits per minute on a specific route
+    plugins: { // If you want to override the default values
+       "hapi-ratelimit": {
+         limit: 100, 
+         duration: 60
+       } //limits to one hundred hits per minute on a specific route
     }
   }
 });
-server.pack.register({
-    options: rateOpts,
-    plugin: hratelimit
-  }, 
+
+connection.register({
+    register: hratelimit,
+    options: rateOpts
+  },
   function(err) {
     console.log(err);
   }
 );
 ```
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a fork from the [creativelive](https://github.com/creativelive/hapi-rate
 ##Installation
 
 ```
-npm install hapi-ratelimit/franciscogouveia
+npm install franciscogouveia/hapi-ratelimit
 ```
 
 ## Usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ exports.register = function(plugin, options, next) {
   var settings = Hoek.applyToDefaults(internals.defaults, options);
   var redisClient = redis.createClient(options.redis.port, options.redis.host, options.redis.options);
 
-  plugin.ext('onPreAuth', function(request, callback) {
+  plugin.ext('onPreAuth', function(request, reply) {
     var route = request.route;
     var routeLimit = route.plugins && route.plugins['hapi-ratelimit'];
     if (!routeLimit && settings.global.limit > 0) {
@@ -40,7 +40,7 @@ exports.register = function(plugin, options, next) {
       var error = null;
       routeLimiter.get(function(err, rateLimit) {
         if (err) {
-          return callback(err);
+          return reply(err);
         }
         request.plugins['hapi-ratelimit'] = {};
         request.plugins['hapi-ratelimit'].limit = rateLimit.total;
@@ -54,15 +54,17 @@ exports.register = function(plugin, options, next) {
           error.output.headers['X-Rate-Limit-Remaining'] = request.plugins['hapi-ratelimit'].remaining;
           error.output.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
           error.reformat();
+          return reply(error);
+        } else {
+          return reply.continue();
         }
-        return callback(error);
       });
     } else {
-      return callback();
+      return reply.continue();
     }
   });
 
-  plugin.ext('onPostHandler', function(request, callback) {
+  plugin.ext('onPostHandler', function(request, reply) {
     var response;
     if ('hapi-ratelimit' in request.plugins) {
       response = request.response;
@@ -72,7 +74,7 @@ exports.register = function(plugin, options, next) {
         response.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;
       }
     }
-    callback();
+    reply.continue();
   });
   next();
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Boom = require('boom');
 var redis = require('redis');
 var Hoek = require('hoek');
 var Limiter = require('ratelimiter');
@@ -48,8 +49,7 @@ exports.register = function(plugin, options, next) {
         request.plugins['hapi-ratelimit'].reset = rateLimit.reset;
 
         if (rateLimit.remaining <= 0) {
-          error = plugin.hapi.error.badRequest('Rate limit exceeded');
-          error.output.statusCode = 429; // Assign a Too Many Requests response
+          error = Boom.tooManyRequests('Rate limit exceeded');          
           error.output.headers['X-Rate-Limit-Limit'] = request.plugins['hapi-ratelimit'].limit;
           error.output.headers['X-Rate-Limit-Remaining'] = request.plugins['hapi-ratelimit'].remaining;
           error.output.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-ratelimit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A rate limiting plugin for HAPI.",
   "main": "index.js",
   "scripts": {
@@ -16,9 +16,10 @@
   "author": "Aaron Elligsen (https://github.com/cl-aaron, https://github.com/hath995)",
   "license": "MIT",
   "dependencies": {
-    "redis": "~0.10.0",
+    "boom": "^2.6.1",
+    "hoek": "~2.3.0",
     "ratelimiter": "~2.0.0",
-    "hoek": "~2.3.0"
+    "redis": "~0.10.0"
   },
   "devDependencies": {
     "hapi": ">=8.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hoek": "~2.3.0"
   },
   "devDependencies": {
-    "hapi": "~6.0.0",
+    "hapi": ">=8.0.0",
     "supertest": "~0.8.3",
     "simple-ansi": "0.0.1",
     "moment": "~2.5.1",

--- a/tests/testserver.js
+++ b/tests/testserver.js
@@ -5,8 +5,14 @@ var ansi = require('simple-ansi');
 var moment = require('moment');
 
 var debug = true;
-var server = new Hapi.Server('localhost', 8081, {});
-server.route([{
+var server = new Hapi.Server();
+
+var connection = server.connection({
+  port: 8081,
+  labels: 'test'
+})
+
+connection.route([{
   method: 'GET',
   path: '/test',
   handler: function(request, reply) {
@@ -42,9 +48,9 @@ var rateopts = {
     duration: 20
   }
 };
-server.pack.register({
+connection.register({
   options: rateopts,
-  plugin: require('../../hapi-ratelimit')
+  register: require('../../hapi-ratelimit')
 }, {}, function(err) {
   if (err) {
     console.log(err);


### PR DESCRIPTION
The changes I've made are stable now for a hapi 8 release. Refactored also the testserver.js file with hapi 8 code.

To test it:

```
node tests/testserver.js
```

When the limit is reached, the following response is given (as expected):

```javascript
{"statusCode":429,"error":"Too Many Requests","message":"Rate limit exceeded"}
```

**Note:** might be not backward compatible with older versions of hapi.