### PR TITLE
Fix Hapi 8.2+ error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+
+node_js:
+  - 0.10
+  - 0.12

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ exports.register = function(plugin, options, next) {
 
   plugin.ext('onPreAuth', function(request, reply) {
     var route = request.route;
-    var routeLimit = route.plugins && route.plugins['hapi-ratelimit'];
+    var routeLimit = route.settings.plugins && route.settings.plugins['hapi-ratelimit'];
     if (!routeLimit && settings.global.limit > 0) {
       routeLimit = settings.global;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ exports.register = function(plugin, options, next) {
         request.plugins['hapi-ratelimit'].reset = rateLimit.reset;
 
         if (rateLimit.remaining <= 0) {
-          error = Boom.tooManyRequests('Rate limit exceeded');          
+          error = Boom.tooManyRequests('Rate limit exceeded');
           error.output.headers['X-Rate-Limit-Limit'] = request.plugins['hapi-ratelimit'].limit;
           error.output.headers['X-Rate-Limit-Remaining'] = request.plugins['hapi-ratelimit'].remaining;
           error.output.headers['X-Rate-Limit-Reset'] = request.plugins['hapi-ratelimit'].reset;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A rate limiting plugin for HAPI.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js lint"
+    "test": "gulp lint"
   },
   "keywords": [
     "rate-limit",
@@ -22,17 +22,18 @@
     "redis": "~0.10.0"
   },
   "devDependencies": {
-    "hapi": ">=8.0.0",
-    "supertest": "~0.8.3",
-    "simple-ansi": "0.0.1",
-    "moment": "~2.5.1",
-    "mocha": "~1.18.2",
     "async": "~0.6.2",
-    "minimist": "^0.1.0",
-    "gulp-jsbeautifier": "0.0.2",
-    "gulp-diff": ">=0.1.4",
     "confidence": ">=0.12.1",
-    "gulp-eslint": ">=0.1.7"
+    "gulp": "^3.9.0",
+    "gulp-diff": ">=0.1.4",
+    "gulp-eslint": ">=0.1.7",
+    "gulp-jsbeautifier": "0.0.2",
+    "hapi": ">=8.0.0",
+    "minimist": "^0.1.0",
+    "mocha": "~1.18.2",
+    "moment": "~2.5.1",
+    "simple-ansi": "0.0.1",
+    "supertest": "~0.8.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With 8.2+ version of Hapi, route plugins are now in the `settings`
property of it.

This should fix #15 